### PR TITLE
feat: add auth button component for login/logout

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import Link from 'next/link'
 import { useUser } from '@auth0/nextjs-auth0/client'
+import AuthButton from '../components/AuthButton'
 
 export default function Home() {
   const { user, error, isLoading } = useUser()
@@ -12,25 +12,8 @@ export default function Home() {
       <p className="mb-6 text-center text-lg">Votre plateforme de gestion de livraisons</p>
       {isLoading && <p>Chargement...</p>}
       {error && <p>Erreur: {error.message}</p>}
-      {!user && (
-        <Link
-          href="/api/auth/login"
-          className="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
-        >
-          Se connecter
-        </Link>
-      )}
-      {user && (
-        <>
-          <p className="mb-4">Bonjour {user.name}</p>
-          <Link
-            href="/api/auth/logout"
-            className="rounded bg-gray-600 px-4 py-2 text-white hover:bg-gray-700"
-          >
-            Se déconnecter
-          </Link>
-        </>
-      )}
+      {user && <p className="mb-4">Bonjour {user.name}</p>}
+      <AuthButton />
     </main>
   )
 }

--- a/frontend/components/AuthButton.tsx
+++ b/frontend/components/AuthButton.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import Link from 'next/link'
+import { useUser } from '@auth0/nextjs-auth0/client'
+
+export default function AuthButton() {
+  const { user } = useUser()
+
+  if (!user) {
+    return (
+      <Link
+        href="/api/auth/login"
+        className="rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+      >
+        Se connecter
+      </Link>
+    )
+  }
+
+  return (
+    <Link
+      href="/api/auth/logout"
+      className="rounded bg-gray-600 px-4 py-2 text-white hover:bg-gray-700"
+    >
+      Se déconnecter
+    </Link>
+  )
+}


### PR DESCRIPTION
## Summary
- factor out login/logout controls into `AuthButton` component
- show greeting and auth button on the home page

## Testing
- `npm --prefix frontend run lint`
- `npm --prefix frontend test` *(fails: Missing script "test")*
- `make test` *(fails: docker: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b09ed250832c9641d3ddb7362cb8