### PR TITLE
Remove deprecated Next.js appDir config

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,8 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  experimental: {
-    appDir: true
-  }
-}
+const nextConfig = {}
 
 module.exports = nextConfig


### PR DESCRIPTION
## Summary
- clean up Next.js config by removing obsolete `experimental.appDir`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9d608de64832c93e95d66ac1ff4ac