### PR TITLE
feat: manager client dashboard

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -2,18 +2,20 @@
 
 import { useUser } from '@auth0/nextjs-auth0/client'
 import AuthButton from '../components/AuthButton'
+import ClientManager from '../components/ClientManager'
 
 export default function Home() {
   const { user, error, isLoading } = useUser()
 
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center p-8">
-      <h1 className="mb-2 text-4xl font-bold">Delivops Frontend</h1>
+    <main className="flex min-h-screen flex-col items-center p-8">
+      <h1 className="mb-2 text-4xl font-bold">Delivops</h1>
       <p className="mb-6 text-center text-lg">Votre plateforme de gestion de livraisons</p>
       {isLoading && <p>Chargement...</p>}
       {error && <p>Erreur: {error.message}</p>}
       {user && <p className="mb-4">Bonjour {user.name}</p>}
       <AuthButton />
+      {user && <ClientManager />}
     </main>
   )
 }

--- a/frontend/components/ClientCard.tsx
+++ b/frontend/components/ClientCard.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import { Client } from './types'
+
+type Props = {
+  client: Client
+  onEdit: (client: Client) => void
+  onDelete: (id: string) => void
+}
+
+export default function ClientCard({ client, onEdit, onDelete }: Props) {
+  return (
+    <div className="mb-4 rounded border p-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-xl font-semibold">{client.name}</h3>
+        <div className="space-x-2 text-sm">
+          <button
+            onClick={() => onEdit(client)}
+            className="text-blue-600 hover:underline"
+          >
+            Modifier
+          </button>
+          <button
+            onClick={() => onDelete(client.id)}
+            className="text-red-600 hover:underline"
+          >
+            Supprimer
+          </button>
+        </div>
+      </div>
+
+      {client.enseignes.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-2">
+          {client.enseignes.map((tag, i) => (
+            <span
+              key={i}
+              className="rounded bg-gray-200 px-2 py-1 text-sm"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {client.categories.length > 0 && (
+        <div className="mt-4 flex flex-col gap-2">
+          {client.categories.map((cat) => (
+            <div key={cat.id} className={`rounded p-2 ${cat.color}`}>
+              <p className="font-medium">{cat.name}</p>
+              <p>{parseFloat(cat.price).toFixed(2)} €</p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/components/ClientForm.tsx
+++ b/frontend/components/ClientForm.tsx
@@ -1,0 +1,200 @@
+'use client'
+
+import { useState } from 'react'
+import { Client, TariffCategory } from './types'
+
+const COLORS = ['bg-red-100', 'bg-blue-100', 'bg-green-100', 'bg-yellow-100', 'bg-purple-100', 'bg-pink-100']
+
+type Props = {
+  initialClient?: Client
+  onSubmit: (client: Client) => void
+  onCancel: () => void
+}
+
+export default function ClientForm({ initialClient, onSubmit, onCancel }: Props) {
+  const [name, setName] = useState(initialClient?.name ?? '')
+  const [enseignes, setEnseignes] = useState<string[]>(initialClient?.enseignes ?? [])
+  const [enseigneInput, setEnseigneInput] = useState('')
+  const [categories, setCategories] = useState<TariffCategory[]>(
+    initialClient?.categories ?? []
+  )
+
+  const addCategory = () => {
+    setCategories([
+      ...categories,
+      {
+        id: crypto.randomUUID(),
+        name: '',
+        price: '',
+        color: COLORS[categories.length % COLORS.length],
+      },
+    ])
+  }
+
+  const updateCategory = (
+    id: string,
+    field: 'name' | 'price',
+    value: string
+  ) => {
+    setCategories((prev) =>
+      prev.map((cat) =>
+        cat.id === id
+          ? { ...cat, [field]: field === 'price' ? value : value }
+          : cat
+      )
+    )
+  }
+
+  const removeCategory = (id: string) => {
+    setCategories(categories.filter((c) => c.id !== id))
+  }
+
+  const handleEnseigneKeyDown = (
+    e: React.KeyboardEvent<HTMLInputElement>
+  ) => {
+    if (e.key === 'Enter' && enseigneInput.trim()) {
+      e.preventDefault()
+      setEnseignes([...enseignes, enseigneInput.trim()])
+      setEnseigneInput('')
+    }
+  }
+
+  const removeEnseigne = (index: number) => {
+    setEnseignes(enseignes.filter((_, i) => i !== index))
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    onSubmit({
+      id: initialClient?.id ?? crypto.randomUUID(),
+      name,
+      enseignes,
+      categories: categories.map((c) => ({
+        ...c,
+        price: c.price ? parseFloat(c.price).toFixed(2) : '0.00',
+      })),
+    })
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="mb-6 w-full rounded border p-4"
+    >
+      <div className="mb-4">
+        <label className="mb-1 block font-medium" htmlFor="name">
+          Nom du client donneur d&apos;ordre
+        </label>
+        <input
+          id="name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="w-full rounded border p-2"
+          required
+        />
+      </div>
+
+      <div className="mb-4">
+        <label className="mb-1 block font-medium">Enseignes associées</label>
+        <div className="flex flex-wrap gap-2 mb-2">
+          {enseignes.map((tag, i) => (
+            <span
+              key={i}
+              className="flex items-center gap-1 rounded bg-gray-200 px-2 py-1 text-sm"
+            >
+              {tag}
+              <button
+                type="button"
+                onClick={() => removeEnseigne(i)}
+                className="text-gray-500 hover:text-gray-700"
+              >
+                ×
+              </button>
+            </span>
+          ))}
+        </div>
+        <input
+          value={enseigneInput}
+          onChange={(e) => setEnseigneInput(e.target.value)}
+          onKeyDown={handleEnseigneKeyDown}
+          className="w-full rounded border p-2"
+          placeholder="Tapez une enseigne et appuyez sur Entrée"
+        />
+      </div>
+
+      <div className="mb-4">
+        <button
+          type="button"
+          onClick={addCategory}
+          className="rounded bg-green-600 px-3 py-1 text-white"
+        >
+          Ajouter une catégorie de groupe tarifaire
+        </button>
+      </div>
+
+      {categories.map((cat) => (
+        <div
+          key={cat.id}
+          className={`mb-4 rounded p-4 ${cat.color} border`}
+        >
+          <div className="mb-2 flex justify-between">
+            <span className="font-medium">Catégorie de colis</span>
+            <button
+              type="button"
+              onClick={() => removeCategory(cat.id)}
+              className="text-sm text-red-600 hover:underline"
+            >
+              Supprimer
+            </button>
+          </div>
+          <div className="mb-2">
+            <input
+              type="text"
+              value={cat.name}
+              onChange={(e) => updateCategory(cat.id, 'name', e.target.value)}
+              placeholder="Nom de la catégorie"
+              className="w-full rounded border p-2"
+              required
+            />
+          </div>
+          <div>
+            <input
+              type="number"
+              step="0.01"
+              value={cat.price}
+              onChange={(e) => updateCategory(cat.id, 'price', e.target.value)}
+              onBlur={(e) =>
+                updateCategory(
+                  cat.id,
+                  'price',
+                  e.target.value
+                    ? parseFloat(e.target.value).toFixed(2)
+                    : '0.00'
+                )
+              }
+              placeholder="Tarif"
+              className="w-full rounded border p-2"
+              required
+            />
+          </div>
+        </div>
+      ))}
+
+      <div className="flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded border px-4 py-2"
+        >
+          Annuler
+        </button>
+        <button
+          type="submit"
+          className="rounded bg-blue-600 px-4 py-2 text-white"
+        >
+          {initialClient ? 'Enregistrer' : 'Ajouter'}
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/frontend/components/ClientManager.tsx
+++ b/frontend/components/ClientManager.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import { useState } from 'react'
+import ClientForm from './ClientForm'
+import ClientCard from './ClientCard'
+import { Client } from './types'
+
+export default function ClientManager() {
+  const [clients, setClients] = useState<Client[]>([])
+  const [showForm, setShowForm] = useState(false)
+  const [editing, setEditing] = useState<Client | null>(null)
+
+  const handleSubmit = (client: Client) => {
+    if (editing) {
+      setClients((prev) =>
+        prev.map((c) => (c.id === client.id ? client : c))
+      )
+    } else {
+      setClients((prev) => [client, ...prev])
+    }
+    setEditing(null)
+    setShowForm(false)
+  }
+
+  const handleEdit = (client: Client) => {
+    setEditing(client)
+    setShowForm(true)
+  }
+
+  const handleDelete = (id: string) => {
+    setClients((prev) => prev.filter((c) => c.id !== id))
+  }
+
+  return (
+    <div className="mt-8 w-full max-w-3xl">
+      <button
+        onClick={() => {
+          setEditing(null)
+          setShowForm(true)
+        }}
+        className="mb-4 rounded bg-blue-600 px-4 py-2 text-white"
+      >
+        Ajouter un client donneur d&apos;ordre
+      </button>
+
+      {showForm && (
+        <ClientForm
+          initialClient={editing ?? undefined}
+          onSubmit={handleSubmit}
+          onCancel={() => {
+            setEditing(null)
+            setShowForm(false)
+          }}
+        />
+      )}
+
+      {clients.length > 0 && (
+        <h2 className="mb-2 text-2xl font-semibold">
+          Récapitulatif des clients
+        </h2>
+      )}
+
+      {clients.map((client) => (
+        <ClientCard
+          key={client.id}
+          client={client}
+          onEdit={handleEdit}
+          onDelete={handleDelete}
+        />
+      ))}
+    </div>
+  )
+}

--- a/frontend/components/types.ts
+++ b/frontend/components/types.ts
@@ -1,0 +1,13 @@
+export type TariffCategory = {
+  id: string;
+  name: string;
+  price: string;
+  color: string;
+};
+
+export type Client = {
+  id: string;
+  name: string;
+  enseignes: string[];
+  categories: TariffCategory[];
+};


### PR DESCRIPTION
## Summary
- remove `Frontend` from homepage header
- add dashboard to add, edit and remove clients with enseignes and tariff categories

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c192584ad0832c9c20550f19b86aab