### PR TITLE
feat: manager client dashboard

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -2,18 +2,20 @@
 
 import { useUser } from '@auth0/nextjs-auth0/client'
 import AuthButton from '../components/AuthButton'
+import ClientManager from '../components/ClientManager'
 
 export default function Home() {
   const { user, error, isLoading } = useUser()
 
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center p-8">
-      <h1 className="mb-2 text-4xl font-bold">Delivops Frontend</h1>
+    <main className="flex min-h-screen flex-col items-center p-8">
+      <h1 className="mb-2 text-4xl font-bold">Delivops</h1>
       <p className="mb-6 text-center text-lg">Votre plateforme de gestion de livraisons</p>
       {isLoading && <p>Chargement...</p>}
       {error && <p>Erreur: {error.message}</p>}
       {user && <p className="mb-4">Bonjour {user.name}</p>}
       <AuthButton />
+      {user && <ClientManager />}
     </main>
   )
 }

--- a/frontend/components/CategoryForm.tsx
+++ b/frontend/components/CategoryForm.tsx
@@ -1,0 +1,120 @@
+'use client'
+
+import { useState } from 'react'
+import { TariffCategory } from './types'
+
+type Props = {
+  initialCategory?: TariffCategory
+  onSubmit: (category: TariffCategory) => void
+  onCancel: () => void
+}
+
+export default function CategoryForm({ initialCategory, onSubmit, onCancel }: Props) {
+  const [name, setName] = useState(initialCategory?.name ?? '')
+  const [price, setPrice] = useState(initialCategory?.price ?? '')
+  const [enseignes, setEnseignes] = useState<string[]>(initialCategory?.enseignes ?? [])
+  const [enseigneInput, setEnseigneInput] = useState('')
+
+  const handleEnseigneKeyDown = (
+    e: React.KeyboardEvent<HTMLInputElement>
+  ) => {
+    if (e.key === 'Enter' && enseigneInput.trim()) {
+      e.preventDefault()
+      setEnseignes([...enseignes, enseigneInput.trim()])
+      setEnseigneInput('')
+    }
+  }
+
+  const removeEnseigne = (index: number) => {
+    setEnseignes(enseignes.filter((_, i) => i !== index))
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    onSubmit({
+      id: initialCategory?.id ?? crypto.randomUUID(),
+      name,
+      price: price ? parseFloat(price).toFixed(2) : '0.00',
+      enseignes,
+      color: initialCategory?.color ?? '',
+    })
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="mb-6 w-full rounded border p-4">
+      <div className="mb-4">
+        <label className="mb-1 block font-medium" htmlFor="name">
+          Nom de la catégorie
+        </label>
+        <input
+          id="name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="w-full rounded border p-2"
+          placeholder="Nom de la catégorie (ex : Colis standard, Cartons ...)"
+          required
+        />
+      </div>
+      <div className="mb-4">
+        <label className="mb-1 block font-medium" htmlFor="price">
+          Tarif
+        </label>
+        <input
+          id="price"
+          type="number"
+          step="0.01"
+          value={price}
+          onChange={(e) => setPrice(e.target.value)}
+          onBlur={(e) =>
+            setPrice(e.target.value ? parseFloat(e.target.value).toFixed(2) : '0.00')
+          }
+          className="w-full rounded border p-2"
+          placeholder="Tarif en €"
+          required
+        />
+      </div>
+      <div className="mb-4">
+        <label className="mb-1 block font-medium">Enseignes associées</label>
+        <div className="mb-2 flex flex-wrap gap-2">
+          {enseignes.map((tag, i) => (
+            <span
+              key={i}
+              className="flex items-center gap-1 rounded bg-gray-200 px-2 py-1 text-sm"
+            >
+              {tag}
+              <button
+                type="button"
+                onClick={() => removeEnseigne(i)}
+                className="text-gray-500 hover:text-gray-700"
+              >
+                ×
+              </button>
+            </span>
+          ))}
+        </div>
+        <input
+          value={enseigneInput}
+          onChange={(e) => setEnseigneInput(e.target.value)}
+          onKeyDown={handleEnseigneKeyDown}
+          className="w-full rounded border p-2"
+          placeholder="Tapez une enseigne et appuyez sur Entrée"
+        />
+      </div>
+      <div className="flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded border px-4 py-2"
+        >
+          Annuler
+        </button>
+        <button
+          type="submit"
+          className="rounded bg-blue-600 px-4 py-2 text-white"
+        >
+          {initialCategory ? 'Enregistrer' : 'Ajouter'}
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/frontend/components/ClientCard.tsx
+++ b/frontend/components/ClientCard.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { Client, TariffCategory } from './types'
+
+type Props = {
+  client: Client
+  onEdit: (client: Client) => void
+  onDelete: (id: string) => void
+  onAddCategory: (client: Client) => void
+  onEditCategory: (client: Client, category: TariffCategory) => void
+  onDeleteCategory: (clientId: string, categoryId: string) => void
+}
+
+export default function ClientCard({
+  client,
+  onEdit,
+  onDelete,
+  onAddCategory,
+  onEditCategory,
+  onDeleteCategory,
+}: Props) {
+  return (
+    <div className="mb-4 rounded border p-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-xl font-semibold">{client.name}</h3>
+        <div className="space-x-2 text-sm">
+          <button
+            onClick={() => onEdit(client)}
+            className="text-blue-600 hover:underline"
+          >
+            Modifier
+          </button>
+          <button
+            onClick={() => onDelete(client.id)}
+            className="text-red-600 hover:underline"
+          >
+            Supprimer
+          </button>
+        </div>
+      </div>
+      <div className="mt-2">
+        <button
+          onClick={() => onAddCategory(client)}
+          className="rounded bg-green-600 px-3 py-1 text-sm text-white"
+        >
+          Ajouter une catégorie de groupe tarifaire
+        </button>
+      </div>
+      {client.categories.length > 0 && (
+        <div className="mt-4 flex flex-col gap-2">
+          {client.categories.map((cat) => (
+            <div key={cat.id} className={`rounded p-2 ${cat.color}`}>
+              <div className="flex justify-between">
+                <div>
+                  <p className="font-medium">{cat.name}</p>
+                  <p>{parseFloat(cat.price).toFixed(2)} €</p>
+                  {cat.enseignes.length > 0 && (
+                    <div className="mt-1 flex flex-wrap gap-2">
+                      {cat.enseignes.map((tag, i) => (
+                        <span
+                          key={i}
+                          className="rounded bg-gray-200 px-2 py-1 text-xs"
+                        >
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </div>
+                <div className="space-x-2 text-sm">
+                  <button
+                    onClick={() => onEditCategory(client, cat)}
+                    className="text-blue-600 hover:underline"
+                  >
+                    Modifier
+                  </button>
+                  <button
+                    onClick={() => onDeleteCategory(client.id, cat.id)}
+                    className="text-red-600 hover:underline"
+                  >
+                    Supprimer
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/components/ClientForm.tsx
+++ b/frontend/components/ClientForm.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { useState } from 'react'
+import { Client } from './types'
+
+type Props = {
+  initialClient?: Client
+  onSubmit: (client: Client) => void
+  onCancel: () => void
+}
+
+export default function ClientForm({ initialClient, onSubmit, onCancel }: Props) {
+  const [name, setName] = useState(initialClient?.name ?? '')
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    onSubmit({
+      id: initialClient?.id ?? crypto.randomUUID(),
+      name,
+      categories: initialClient?.categories ?? [],
+    })
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="mb-6 w-full rounded border p-4">
+      <div className="mb-4">
+        <label htmlFor="name" className="mb-1 block font-medium">
+          Nom du client donneur d&apos;ordre
+        </label>
+        <input
+          id="name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="w-full rounded border p-2"
+          required
+        />
+      </div>
+      <div className="flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded border px-4 py-2"
+        >
+          Annuler
+        </button>
+        <button
+          type="submit"
+          className="rounded bg-blue-600 px-4 py-2 text-white"
+        >
+          {initialClient ? 'Enregistrer' : 'Ajouter'}
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/frontend/components/ClientManager.tsx
+++ b/frontend/components/ClientManager.tsx
@@ -1,0 +1,125 @@
+'use client'
+
+import { useState } from 'react'
+import ClientForm from './ClientForm'
+import CategoryForm from './CategoryForm'
+import ClientCard from './ClientCard'
+import { Client, TariffCategory } from './types'
+
+const COLORS = ['bg-red-100','bg-blue-100','bg-green-100','bg-yellow-100','bg-purple-100','bg-pink-100']
+
+export default function ClientManager() {
+  const [clients, setClients] = useState<Client[]>([])
+  const [showClientForm, setShowClientForm] = useState(false)
+  const [editingClient, setEditingClient] = useState<Client | null>(null)
+
+  const [showCategoryForm, setShowCategoryForm] = useState(false)
+  const [categoryClient, setCategoryClient] = useState<Client | null>(null)
+  const [editingCategory, setEditingCategory] = useState<TariffCategory | null>(null)
+
+  const handleClientSubmit = (client: Client) => {
+    if (editingClient) {
+      setClients(prev => prev.map(c => c.id === client.id ? client : c))
+    } else {
+      setClients(prev => [client, ...prev])
+    }
+    setEditingClient(null)
+    setShowClientForm(false)
+  }
+
+  const handleEditClient = (client: Client) => {
+    setEditingClient(client)
+    setShowClientForm(true)
+  }
+
+  const handleDeleteClient = (id: string) => {
+    setClients(prev => prev.filter(c => c.id !== id))
+  }
+
+  const handleAddCategory = (client: Client) => {
+    setCategoryClient(client)
+    setEditingCategory(null)
+    setShowCategoryForm(true)
+  }
+
+  const handleEditCategory = (client: Client, category: TariffCategory) => {
+    setCategoryClient(client)
+    setEditingCategory(category)
+    setShowCategoryForm(true)
+  }
+
+  const handleDeleteCategory = (clientId: string, categoryId: string) => {
+    setClients(prev => prev.map(c =>
+      c.id === clientId ? { ...c, categories: c.categories.filter(cat => cat.id !== categoryId) } : c
+    ))
+  }
+
+  const handleCategorySubmit = (category: TariffCategory) => {
+    if (!categoryClient) return
+    setClients(prev => prev.map(c => {
+      if (c.id !== categoryClient.id) return c
+      const categories = editingCategory
+        ? c.categories.map(cat => cat.id === category.id ? { ...category, color: editingCategory.color } : cat)
+        : [...c.categories, { ...category, color: COLORS[c.categories.length % COLORS.length] }]
+      return { ...c, categories }
+    }))
+    setEditingCategory(null)
+    setCategoryClient(null)
+    setShowCategoryForm(false)
+  }
+
+  const cancelForms = () => {
+    setEditingClient(null)
+    setShowClientForm(false)
+    setEditingCategory(null)
+    setCategoryClient(null)
+    setShowCategoryForm(false)
+  }
+
+  return (
+    <div className="mt-8 w-full max-w-3xl">
+      <button
+        onClick={() => {
+          setEditingClient(null)
+          setShowClientForm(true)
+        }}
+        className="mb-4 rounded bg-blue-600 px-4 py-2 text-white"
+      >
+        Ajouter un client donneur d&apos;ordre
+      </button>
+
+      {showClientForm && (
+        <ClientForm
+          initialClient={editingClient ?? undefined}
+          onSubmit={handleClientSubmit}
+          onCancel={cancelForms}
+        />
+      )}
+
+      {showCategoryForm && (
+        <CategoryForm
+          initialCategory={editingCategory ?? undefined}
+          onSubmit={handleCategorySubmit}
+          onCancel={cancelForms}
+        />
+      )}
+
+      {!showClientForm && !showCategoryForm && clients.length > 0 && (
+        <>
+          <h2 className="mb-2 text-2xl font-semibold">Récapitulatif des clients</h2>
+          {clients.map(client => (
+            <ClientCard
+              key={client.id}
+              client={client}
+              onEdit={handleEditClient}
+              onDelete={handleDeleteClient}
+              onAddCategory={handleAddCategory}
+              onEditCategory={handleEditCategory}
+              onDeleteCategory={handleDeleteCategory}
+            />
+          ))}
+        </>
+      )}
+    </div>
+  )
+}

--- a/frontend/components/types.ts
+++ b/frontend/components/types.ts
@@ -1,0 +1,13 @@
+export type TariffCategory = {
+  id: string;
+  name: string;
+  price: string;
+  enseignes: string[];
+  color: string;
+};
+
+export type Client = {
+  id: string;
+  name: string;
+  categories: TariffCategory[];
+};


### PR DESCRIPTION
## Summary
- associate enseignes with tariff categories instead of clients
- add dedicated tariff category form shown after client creation
- hide client recap while editing categories and update field placeholders

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c192584ad0832c9c20550f19b86aab