### PR TITLE
Fix ClientManager state declaration

### DIFF
--- a/frontend/components/ClientManager.tsx
+++ b/frontend/components/ClientManager.tsx
@@ -10,7 +10,7 @@ const COLORS = ['bg-red-100','bg-blue-100','bg-green-100','bg-yellow-100','bg-pu
 
 export default function ClientManager() {
   const [clients, setClients] = useState<Client[]>([])
-  the [showClientForm, setShowClientForm] = useState(false)
+  const [showClientForm, setShowClientForm] = useState(false)
   const [editingClient, setEditingClient] = useState<Client | null>(null)
 
   const [showCategoryForm, setShowCategoryForm] = useState(false)


### PR DESCRIPTION
## Summary
- fix state declaration in ClientManager to use `const`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1a23da240832cb49a5c455ac7f2e6