### PR TITLE
feat: implement chauffeur invitations and quotas

### DIFF
--- a/backend/app/api/chauffeurs.py
+++ b/backend/app/api/chauffeurs.py
@@ -1,0 +1,52 @@
+from secrets import token_urlsafe
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.db.session import get_db
+from app.api.deps import get_tenant_id
+from app.models.chauffeur import Chauffeur
+from app.models.tenant import Tenant
+from app.schemas.chauffeur import ChauffeurCreate, ChauffeurRead
+from app.core.email import send_activation_email
+
+router = APIRouter(prefix="/chauffeurs", tags=["chauffeurs"])
+
+
+@router.get("/count")
+def count_chauffeurs(
+    db: Session = Depends(get_db),
+    tenant_id: str = Depends(get_tenant_id),
+):
+    tenant_id_int = int(tenant_id)
+    count = db.query(Chauffeur).filter(Chauffeur.tenant_id == tenant_id_int).count()
+    tenant = db.get(Tenant, tenant_id_int)
+    subscribed = tenant.max_chauffeurs if tenant else 0
+    return {"count": count, "subscribed": subscribed}
+
+
+@router.post("/", response_model=ChauffeurRead, status_code=201)
+def create_chauffeur(
+    chauffeur_in: ChauffeurCreate,
+    db: Session = Depends(get_db),
+    tenant_id: str = Depends(get_tenant_id),
+):
+    tenant_id_int = int(tenant_id)
+    tenant = db.get(Tenant, tenant_id_int)
+    if tenant is None:
+        raise HTTPException(status_code=404, detail="Tenant not found")
+    current = db.query(Chauffeur).filter(Chauffeur.tenant_id == tenant_id_int).count()
+    if tenant.max_chauffeurs and current >= tenant.max_chauffeurs:
+        raise HTTPException(status_code=400, detail="Driver limit reached")
+    chauffeur = Chauffeur(
+        tenant_id=tenant_id_int,
+        email=chauffeur_in.email,
+        display_name=chauffeur_in.display_name,
+    )
+    db.add(chauffeur)
+    db.commit()
+    db.refresh(chauffeur)
+    token = token_urlsafe(32)
+    activation_link = f"https://example.com/activate?token={token}"
+    send_activation_email(chauffeur.email, activation_link)
+    return chauffeur

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -1,0 +1,9 @@
+from fastapi import Header, HTTPException
+
+from app.core.config import settings
+
+
+def get_tenant_id(x_tenant_id: str = Header(..., alias=settings.tenant_header_name)):
+    if not x_tenant_id:
+        raise HTTPException(status_code=400, detail="Missing tenant header")
+    return x_tenant_id

--- a/backend/app/core/email.py
+++ b/backend/app/core/email.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+
+def send_activation_email(email: str, link: str) -> None:
+    """Send activation link to a driver via email.
+
+    This is a stub implementation that simply prints the link.
+    """
+    print(f"Activation email to {email}: {link}")

--- a/backend/app/models/chauffeur.py
+++ b/backend/app/models/chauffeur.py
@@ -7,6 +7,7 @@ from .base import Base
 class Chauffeur(Base):
     tenant_id = Column(Integer, ForeignKey('tenant.id'), nullable=False, index=True)
     user_id = Column(Integer, ForeignKey('user.id'), nullable=True)
+    email = Column(String, unique=True, nullable=False)
     display_name = Column(String, nullable=False)
     is_active = Column(Boolean, default=True)
 

--- a/backend/app/models/tenant.py
+++ b/backend/app/models/tenant.py
@@ -8,3 +8,4 @@ class Tenant(Base):
     slug = Column(String, unique=True, nullable=False)
     timezone = Column(String, default="UTC")
     locale = Column(String, default="fr")
+    max_chauffeurs = Column(Integer, default=0)

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,0 +1,6 @@
+from .chauffeur import ChauffeurCreate, ChauffeurRead
+
+__all__ = [
+    'ChauffeurCreate',
+    'ChauffeurRead',
+]

--- a/backend/app/schemas/chauffeur.py
+++ b/backend/app/schemas/chauffeur.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel
+
+
+class ChauffeurCreate(BaseModel):
+    email: str
+    display_name: str
+
+
+class ChauffeurRead(BaseModel):
+    id: int
+    email: str
+    display_name: str
+    is_active: bool
+
+    class Config:
+        orm_mode = True

--- a/backend/migrations/versions/0002_chauffeur_email_tenant_limit.py
+++ b/backend/migrations/versions/0002_chauffeur_email_tenant_limit.py
@@ -1,0 +1,26 @@
+"""add chauffeur email and tenant max_chauffeurs
+
+Revision ID: 0002_chauffeur_email_tenant_limit
+Revises: 0001_initial
+Create Date: 2024-05-18 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '0002_chauffeur_email_tenant_limit'
+down_revision = '0001_initial'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('tenant', sa.Column('max_chauffeurs', sa.Integer(), nullable=True))
+    op.add_column('chauffeur', sa.Column('email', sa.String(), nullable=False))
+    op.create_unique_constraint('uq_chauffeur_email', 'chauffeur', ['email'])
+
+
+def downgrade() -> None:
+    op.drop_constraint('uq_chauffeur_email', 'chauffeur', type_='unique')
+    op.drop_column('chauffeur', 'email')
+    op.drop_column('tenant', 'max_chauffeurs')

--- a/backend/tests/test_chauffeurs.py
+++ b/backend/tests/test_chauffeurs.py
@@ -1,0 +1,75 @@
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.db.session import get_db
+from app.models.base import Base
+from app.models.tenant import Tenant
+from app.models.chauffeur import Chauffeur
+from app.models.user import User
+
+
+def override_get_db():
+    try:
+        db = TestingSessionLocal()
+        yield db
+    finally:
+        db.close()
+
+
+engine = create_engine(
+    "sqlite://",
+    future=True,
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False, future=True)
+Base.metadata.create_all(bind=engine)
+app.dependency_overrides[get_db] = override_get_db
+
+
+def test_create_chauffeur_and_limit(monkeypatch):
+    sent = {}
+
+    def fake_send(email: str, link: str) -> None:
+        sent["email"] = email
+        sent["link"] = link
+
+    monkeypatch.setattr("app.api.chauffeurs.send_activation_email", fake_send)
+
+    client = TestClient(app)
+
+    # create tenant
+    with TestingSessionLocal() as db:
+        tenant = Tenant(name="Acme", slug="acme", max_chauffeurs=1)
+        db.add(tenant)
+        db.commit()
+        db.refresh(tenant)
+        tenant_id = tenant.id
+
+    headers = {"X-Tenant-Id": str(tenant_id)}
+
+    # create first chauffeur
+    response = client.post(
+        "/chauffeurs/",
+        json={"email": "driver1@example.com", "display_name": "Driver One"},
+        headers=headers,
+    )
+    assert response.status_code == 201
+    assert sent["email"] == "driver1@example.com"
+    assert "activate" in sent["link"]
+
+    # count should be 1 and reflect subscription
+    response = client.get("/chauffeurs/count", headers=headers)
+    assert response.status_code == 200
+    assert response.json() == {"count": 1, "subscribed": 1}
+
+    # second chauffeur exceeds limit
+    response = client.post(
+        "/chauffeurs/",
+        json={"email": "driver2@example.com", "display_name": "Driver Two"},
+        headers=headers,
+    )
+    assert response.status_code == 400


### PR DESCRIPTION
## Summary
- track subscribed chauffeur limits per tenant
- allow managers to invite chauffeurs via email with activation link
- expose chauffeur count endpoint and enforce quota

## Testing
- `cd backend && PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1a62bc2e4832c8aeb0b25a423877a