### PR TITLE
feat(chauffeurs): add invite form

### DIFF
--- a/backend/app/api/chauffeurs.py
+++ b/backend/app/api/chauffeurs.py
@@ -1,6 +1,8 @@
 from secrets import token_urlsafe
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
 
 from app.db.session import get_db
@@ -11,6 +13,13 @@ from app.schemas.chauffeur import ChauffeurCreate, ChauffeurRead
 from app.core.email import send_activation_email
 
 router = APIRouter(prefix="/chauffeurs", tags=["chauffeurs"])
+
+templates = Jinja2Templates(directory="app/templates")
+
+
+@router.get("/invite", response_class=HTMLResponse)
+def invite_chauffeur_form(request: Request):
+    return templates.TemplateResponse("invite_chauffeur.html", {"request": request})
 
 
 @router.get("/count")

--- a/backend/app/templates/invite_chauffeur.html
+++ b/backend/app/templates/invite_chauffeur.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Inviter un chauffeur</title>
+</head>
+<body>
+    <h1>Inviter un chauffeur</h1>
+    <p>Quota actuel: <span id="quota"></span></p>
+    <form id="inviteForm" action="/chauffeurs/" method="post">
+        <label for="email">Email:</label>
+        <input type="email" id="email" name="email" required>
+
+        <label for="display_name">Nom affiché:</label>
+        <input type="text" id="display_name" name="display_name" required>
+
+        <button type="submit">Inviter</button>
+    </form>
+    <p id="message"></p>
+
+    <script>
+    async function loadQuota() {
+        try {
+            const res = await fetch('/chauffeurs/count');
+            if (res.ok) {
+                const data = await res.json();
+                document.getElementById('quota').textContent = `${data.count}/${data.subscribed}`;
+            } else {
+                document.getElementById('quota').textContent = 'Erreur';
+            }
+        } catch (err) {
+            document.getElementById('quota').textContent = 'Erreur';
+        }
+    }
+
+    document.getElementById('inviteForm').addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const form = e.target;
+        const body = {
+            email: form.email.value,
+            display_name: form.display_name.value
+        };
+        try {
+            const res = await fetch(form.action, {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify(body)
+            });
+            if (res.ok) {
+                document.getElementById('message').textContent = 'Invitation envoyée';
+                form.reset();
+            } else {
+                const data = await res.json();
+                document.getElementById('message').textContent = data.detail || "Erreur lors de l'invitation";
+            }
+        } catch (err) {
+            document.getElementById('message').textContent = "Erreur lors de l'invitation";
+        }
+        loadQuota();
+    });
+
+    loadQuota();
+    </script>
+</body>
+</html>

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,3 +11,4 @@ loguru
 requests
 pytest
 httpx
+jinja2


### PR DESCRIPTION
## Summary
- add GET /chauffeurs/invite rendering an invite form
- include client-side quota and submission handling template
- declare jinja2 dependency

## Testing
- `PYTHONPATH=backend pytest backend/tests` *(fails: jinja2 must be installed)*
- `pip install jinja2` *(fails: Could not find a version that satisfies the requirement jinja2)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ac656ed8832cb720dfabfefca5c1