### PR TITLE
Pass tenant ID to chauffeur invite form

### DIFF
--- a/backend/app/api/chauffeurs.py
+++ b/backend/app/api/chauffeurs.py
@@ -18,8 +18,10 @@ templates = Jinja2Templates(directory="app/templates")
 
 
 @router.get("/invite", response_class=HTMLResponse)
-def invite_chauffeur_form(request: Request):
-    return templates.TemplateResponse("invite_chauffeur.html", {"request": request})
+def invite_chauffeur_form(request: Request, tenant_id: str = Depends(get_tenant_id)):
+    return templates.TemplateResponse(
+        "invite_chauffeur.html", {"request": request, "tenant_id": tenant_id}
+    )
 
 
 @router.get("/count")

--- a/backend/app/templates/invite_chauffeur.html
+++ b/backend/app/templates/invite_chauffeur.html
@@ -19,9 +19,13 @@
     <p id="message"></p>
 
     <script>
+    const tenantId = "{{ tenant_id }}";
+
     async function loadQuota() {
         try {
-            const res = await fetch('/chauffeurs/count');
+            const res = await fetch('/chauffeurs/count', {
+                headers: { 'X-Tenant-Id': tenantId }
+            });
             if (res.ok) {
                 const data = await res.json();
                 document.getElementById('quota').textContent = `${data.count}/${data.subscribed}`;
@@ -43,7 +47,10 @@
         try {
             const res = await fetch(form.action, {
                 method: 'POST',
-                headers: {'Content-Type': 'application/json'},
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Tenant-Id': tenantId
+                },
                 body: JSON.stringify(body)
             });
             if (res.ok) {

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useUser } from '@auth0/nextjs-auth0/client'
+import Link from 'next/link'
 import AuthButton from '../components/AuthButton'
 import ClientManager from '../components/ClientManager'
 
@@ -15,6 +16,14 @@ export default function Home() {
       {error && <p>Erreur: {error.message}</p>}
       {user && <p className="mb-4">Bonjour {user.name}</p>}
       <AuthButton />
+      {user && (
+        <Link
+          href="/chauffeurs/invite"
+          className="mt-4 rounded bg-green-600 px-4 py-2 text-white"
+        >
+          Inviter un chauffeur
+        </Link>
+      )}
       {user && <ClientManager />}
     </main>
   )


### PR DESCRIPTION
## Summary
- inject tenant ID into chauffeur invite form template
- include tenant header on quota check and invite submission
- add navigation button to reach invite form from web UI

## Testing
- `PYTHONPATH=backend pytest` *(fails: jinja2 must be installed to use Jinja2Templates)*
- `cd frontend && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1b34e1670832cbe592487f156b8a3