### PR TITLE
feat: expose clients and tariff groups to drivers

### DIFF
--- a/backend/app/api/clients.py
+++ b/backend/app/api/clients.py
@@ -1,0 +1,46 @@
+from typing import List
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_tenant_id, require_roles
+from app.db.session import get_db
+from app.models.client import Client
+from app.models.tariff_group import TariffGroup
+from app.schemas.client import ClientWithCategories, CategoryRead
+
+router = APIRouter(prefix="/clients", tags=["clients"])
+
+
+@router.get("/", response_model=List[ClientWithCategories])
+def list_clients(
+    db: Session = Depends(get_db),  # noqa: B008
+    tenant_id: str = Depends(get_tenant_id),  # noqa: B008
+    user: dict = Depends(require_roles("CHAUFFEUR", "ADMIN")),  # noqa: B008
+) -> List[ClientWithCategories]:
+    """Return all active clients with their tariff categories."""
+    tenant_id_int = int(tenant_id)
+    clients = (
+        db.query(Client)
+        .filter(Client.tenant_id == tenant_id_int, Client.is_active.is_(True))
+        .order_by(Client.name)
+        .all()
+    )
+
+    result: List[ClientWithCategories] = []
+    for client in clients:
+        groups = (
+            db.query(TariffGroup)
+            .filter(
+                TariffGroup.tenant_id == tenant_id_int,
+                TariffGroup.client_id == client.id,
+                TariffGroup.is_active.is_(True),
+            )
+            .order_by(TariffGroup.order)
+            .all()
+        )
+        categories = [CategoryRead(id=g.id, name=g.display_name) for g in groups]
+        result.append(
+            ClientWithCategories(id=client.id, name=client.name, categories=categories)
+        )
+    return result

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,6 +7,7 @@ from app.api.tournees import router as tournees_router
 from app.api.saisies import router as saisies_router
 from app.api.tours import router as tours_router
 from app.api.reports import router as reports_router
+from app.api.clients import router as clients_router
 from app.api.deps import get_tenant_id, auth_dependency
 from app.middleware.audit import AuditMiddleware
 from app.core.logging import setup_logging
@@ -29,6 +30,7 @@ app.include_router(tournees_router)
 app.include_router(saisies_router)
 app.include_router(tours_router)
 app.include_router(reports_router)
+app.include_router(clients_router)
 
 
 @app.get("/auth/me")

--- a/backend/app/schemas/client.py
+++ b/backend/app/schemas/client.py
@@ -1,0 +1,14 @@
+from typing import List
+
+from pydantic import BaseModel
+
+
+class CategoryRead(BaseModel):
+    id: int
+    name: str
+
+
+class ClientWithCategories(BaseModel):
+    id: int
+    name: str
+    categories: List[CategoryRead]

--- a/frontend/components/TourneeWizard.tsx
+++ b/frontend/components/TourneeWizard.tsx
@@ -1,46 +1,40 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import Link from 'next/link'
+import { apiFetch } from '../lib/api'
 
 interface Category {
-  id: string
+  id: number
   name: string
 }
 
 interface Client {
-  id: string
+  id: number
   name: string
   categories: Category[]
 }
-
-const CLIENTS: Client[] = [
-  {
-    id: 'c1',
-    name: 'Client A',
-    categories: [
-      { id: 'cat1', name: 'Catégorie 1' },
-      { id: 'cat2', name: 'Catégorie 2' },
-    ],
-  },
-  {
-    id: 'c2',
-    name: 'Client B',
-    categories: [
-      { id: 'cat3', name: 'Catégorie 3' },
-      { id: 'cat4', name: 'Catégorie 4' },
-    ],
-  },
-]
 
 type Mode = 'pickup' | 'delivery'
 
 export default function TourneeWizard({ mode }: { mode: Mode }) {
   const [step, setStep] = useState(1)
+  const [clients, setClients] = useState<Client[]>([])
   const [client, setClient] = useState<Client | null>(null)
   const [selectedCats, setSelectedCats] = useState<Category[]>([])
-  const [quantities, setQuantities] = useState<Record<string, number>>({})
+  const [quantities, setQuantities] = useState<Record<number, number>>({})
   const [error, setError] = useState('')
+
+  useEffect(() => {
+    const fetchClients = async () => {
+      const res = await apiFetch('/clients')
+      if (res.ok) {
+        const data = await res.json()
+        setClients(data)
+      }
+    }
+    fetchClients()
+  }, [])
 
   const labelQty =
     mode === 'pickup'
@@ -75,7 +69,7 @@ export default function TourneeWizard({ mode }: { mode: Mode }) {
     setStep(3)
   }
 
-  const changeQty = (id: string, value: number) => {
+  const changeQty = (id: number, value: number) => {
     setQuantities((prev) => ({ ...prev, [id]: value }))
   }
 
@@ -100,7 +94,7 @@ export default function TourneeWizard({ mode }: { mode: Mode }) {
       {step === 1 && (
         <>
           <h1 className="mb-6 text-3xl font-bold">Choisissez un client</h1>
-          {CLIENTS.map((c) => (
+          {clients.map((c) => (
             <button
               key={c.id}
               onClick={() => selectClient(c)}


### PR DESCRIPTION
## Summary
- expose active clients and their tariff categories through `/clients` API
- load client and category data dynamically in driver tour wizard

## Testing
- `pytest`
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c53860ef18832cac5e176770a2a2bd