### PR TITLE
Handle client creation errors in form

### DIFF
--- a/frontend/components/ClientForm.tsx
+++ b/frontend/components/ClientForm.tsx
@@ -5,9 +5,15 @@ type Props = {
   initialName?: string
   onSubmit: (name: string) => void
   onCancel: () => void
+  error?: string
 }
 
-export default function ClientForm({ initialName, onSubmit, onCancel }: Props) {
+export default function ClientForm({
+  initialName,
+  onSubmit,
+  onCancel,
+  error,
+}: Props) {
   const [name, setName] = useState(initialName ?? '')
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -17,6 +23,7 @@ export default function ClientForm({ initialName, onSubmit, onCancel }: Props) {
 
   return (
     <form onSubmit={handleSubmit} className="mb-6 w-full rounded border p-4">
+      {error && <p className="mb-4 text-red-600">{error}</p>}
       <div className="mb-4">
         <label htmlFor="name" className="mb-1 block font-medium">
           Nom du client donneur d&apos;ordre


### PR DESCRIPTION
## Summary
- show API error messages in client form
- keep client form open when a submission fails

## Testing
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c542bf7710832c8c2362dd1bb3f272