### PR TITLE
Handle missing tenant when creating client

### DIFF
--- a/backend/app/api/clients.py
+++ b/backend/app/api/clients.py
@@ -9,6 +9,7 @@ from app.api.deps import get_tenant_id, require_roles
 from app.db.session import get_db
 from app.models.client import Client
 from app.models.tariff_group import TariffGroup
+from app.models.tenant import Tenant
 from app.schemas.client import (
     ClientWithCategories,
     CategoryRead,
@@ -67,6 +68,9 @@ def create_client(
     user: dict = Depends(require_roles("ADMIN")),  # noqa: B008
 ) -> ClientWithCategories:
     tenant_id_int = int(tenant_id)
+    tenant = db.get(Tenant, tenant_id_int)
+    if tenant is None:
+        raise HTTPException(status_code=404, detail="Tenant not found")
     client = Client(tenant_id=tenant_id_int, name=payload.name, is_active=True)
     db.add(client)
     db.commit()

--- a/backend/tests/test_clients.py
+++ b/backend/tests/test_clients.py
@@ -69,3 +69,10 @@ def test_create_client_and_category_visible_to_driver(client):
         for c in data
     )
 
+
+def test_create_client_missing_tenant_returns_404(client):
+    headers_admin = {"X-Tenant-Id": "999", "X-Dev-Role": "ADMIN"}
+    resp = client.post("/clients/", json={"name": "Test"}, headers=headers_admin)
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Tenant not found"
+


### PR DESCRIPTION
## Summary
- Validate tenant ID before creating a client and return 404 when not found
- Add regression test for missing tenant scenario in client creation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c58446243c832c969277defd2490ea