### PR TITLE
fix: retrieve access token on client

### DIFF
--- a/frontend/app/api/auth/token/route.ts
+++ b/frontend/app/api/auth/token/route.ts
@@ -1,0 +1,11 @@
+import { getAccessToken } from '@auth0/nextjs-auth0'
+import { NextResponse } from 'next/server'
+
+export async function GET() {
+  try {
+    const { accessToken } = await getAccessToken()
+    return NextResponse.json({ accessToken })
+  } catch {
+    return NextResponse.json({}, { status: 401 })
+  }
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -12,7 +12,21 @@ export async function apiFetch(path: string, init: RequestInit = {}) {
   } as Record<string, string>
 
   try {
-    const { accessToken } = await getAccessToken()
+    let accessToken: string | undefined
+
+    if (typeof window === 'undefined') {
+      // Server-side: fetch token directly from the session
+      const token = await getAccessToken()
+      accessToken = token.accessToken
+    } else {
+      // Client-side: retrieve access token through dedicated API route
+      const res = await fetch('/api/auth/token')
+      if (res.ok) {
+        const data = (await res.json()) as { accessToken?: string }
+        accessToken = data.accessToken
+      }
+    }
+
     if (accessToken) {
       headers['Authorization'] = `Bearer ${accessToken}`
     }


### PR DESCRIPTION
## Summary
- fetch access token for browser requests via new API route
- expose `/api/auth/token` endpoint to provide session access token

## Testing
- `make test` *(fails: docker: No such file or directory)*
- `cd frontend && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c58caa57a4832c953288048138de23