### PR TITLE
fix auth dependency to use HTTPAuthorizationCredentials

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -1,4 +1,5 @@
 from fastapi import Depends, Header, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials
 
 from app.core.auth import get_current_user, dev_fake_auth
 from app.core.config import settings
@@ -32,7 +33,8 @@ def auth_dependency(
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid scheme"
         )
-    return get_current_user(token)
+    creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+    return get_current_user(creds)
 
 
 def require_roles(*required_roles: str):


### PR DESCRIPTION
## Summary
- pass HTTPAuthorizationCredentials to `get_current_user` in `auth_dependency`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c813b02104832ca3c4890a24d9fd39