### PR TITLE
Expose tariff prices for clients and send driver tours

### DIFF
--- a/backend/app/schemas/client.py
+++ b/backend/app/schemas/client.py
@@ -1,11 +1,17 @@
 from typing import List
 
-from pydantic import BaseModel
+from decimal import Decimal
+from pydantic import BaseModel, Field, ConfigDict
 
 
 class CategoryRead(BaseModel):
     id: int
     name: str
+    unit_price_ex_vat: Decimal | None = Field(
+        default=None, alias="unitPriceExVat"
+    )
+
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
 
 class CategoryCreate(BaseModel):

--- a/backend/tests/test_clients.py
+++ b/backend/tests/test_clients.py
@@ -1,4 +1,5 @@
 import pytest
+from decimal import Decimal
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -65,7 +66,10 @@ def test_create_client_and_category_visible_to_driver(client):
     assert resp.status_code == 200
     data = resp.json()
     assert any(
-        c["name"] == "Client X" and c["categories"] and c["categories"][0]["name"] == "Cat A"
+        c["name"] == "Client X"
+        and c["categories"]
+        and c["categories"][0]["name"] == "Cat A"
+        and Decimal(c["categories"][0]["unitPriceExVat"]) == Decimal("0")
         for c in data
     )
 


### PR DESCRIPTION
## Summary
- include active tariff prices when listing clients and categories
- allow drivers to submit tour data from the wizard
- cover price field in schema and tests

## Testing
- `pytest`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c818abea1c832c950cce9552772308