### PR TITLE
Expose tariff prices for clients and send driver tours

### DIFF
--- a/backend/app/schemas/client.py
+++ b/backend/app/schemas/client.py
@@ -1,11 +1,17 @@
 from typing import List
 
-from pydantic import BaseModel
+from decimal import Decimal
+from pydantic import BaseModel, Field, ConfigDict
 
 
 class CategoryRead(BaseModel):
     id: int
     name: str
+    unit_price_ex_vat: Decimal | None = Field(
+        default=None, alias="unitPriceExVat"
+    )
+
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
 
 class CategoryCreate(BaseModel):

--- a/backend/tests/test_clients.py
+++ b/backend/tests/test_clients.py
@@ -1,4 +1,5 @@
 import pytest
+from decimal import Decimal
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -65,7 +66,10 @@ def test_create_client_and_category_visible_to_driver(client):
     assert resp.status_code == 200
     data = resp.json()
     assert any(
-        c["name"] == "Client X" and c["categories"] and c["categories"][0]["name"] == "Cat A"
+        c["name"] == "Client X"
+        and c["categories"]
+        and c["categories"][0]["name"] == "Cat A"
+        and Decimal(c["categories"][0]["unitPriceExVat"]) == Decimal("0")
         for c in data
     )
 

--- a/frontend/app/cloturer/page.tsx
+++ b/frontend/app/cloturer/page.tsx
@@ -6,11 +6,20 @@ import TourneeWizard from '../../components/TourneeWizard'
 import { normalizeRoles } from '../../lib/roles'
 
 export default function CloturerPage() {
-  const { user } = useUser()
+  const { user, error, isLoading } = useUser()
   const roles = normalizeRoles(
     ((user?.['https://delivops/roles'] as string[]) || [])
   )
-  if (!roles.includes('CHAUFFEUR')) {
+
+  if (isLoading) {
+    return (
+      <main className="flex min-h-screen flex-col items-center p-8">
+        <p>Chargement...</p>
+      </main>
+    )
+  }
+
+  if (error || !roles.includes('CHAUFFEUR')) {
     return (
       <main className="flex min-h-screen flex-col items-center p-8">
         <p className="mb-4">Accès refusé</p>
@@ -20,6 +29,7 @@ export default function CloturerPage() {
       </main>
     )
   }
+
   return <TourneeWizard mode="delivery" />
 }
 

--- a/frontend/app/recuperer/page.tsx
+++ b/frontend/app/recuperer/page.tsx
@@ -6,11 +6,20 @@ import TourneeWizard from '../../components/TourneeWizard'
 import { normalizeRoles } from '../../lib/roles'
 
 export default function RecupererPage() {
-  const { user } = useUser()
+  const { user, error, isLoading } = useUser()
   const roles = normalizeRoles(
     ((user?.['https://delivops/roles'] as string[]) || [])
   )
-  if (!roles.includes('CHAUFFEUR')) {
+
+  if (isLoading) {
+    return (
+      <main className="flex min-h-screen flex-col items-center p-8">
+        <p>Chargement...</p>
+      </main>
+    )
+  }
+
+  if (error || !roles.includes('CHAUFFEUR')) {
     return (
       <main className="flex min-h-screen flex-col items-center p-8">
         <p className="mb-4">Accès refusé</p>
@@ -20,6 +29,7 @@ export default function RecupererPage() {
       </main>
     )
   }
+
   return <TourneeWizard mode="pickup" />
 }
 

--- a/frontend/components/TourneeWizard.tsx
+++ b/frontend/components/TourneeWizard.tsx
@@ -7,6 +7,7 @@ import { apiFetch } from '../lib/api'
 interface Category {
   id: number
   name: string
+  unitPriceExVat?: string
 }
 
 interface Client {
@@ -24,6 +25,7 @@ export default function TourneeWizard({ mode }: { mode: Mode }) {
   const [selectedCats, setSelectedCats] = useState<Category[]>([])
   const [quantities, setQuantities] = useState<Record<number, number>>({})
   const [error, setError] = useState('')
+  const [saving, setSaving] = useState(false)
 
   useEffect(() => {
     const fetchClients = async () => {
@@ -31,6 +33,8 @@ export default function TourneeWizard({ mode }: { mode: Mode }) {
       if (res.ok) {
         const data = await res.json()
         setClients(data)
+      } else if (res.status === 401) {
+        setError('Accès non autorisé')
       }
     }
     fetchClients()
@@ -85,8 +89,28 @@ export default function TourneeWizard({ mode }: { mode: Mode }) {
     setStep(4)
   }
 
-  const validate = () => {
-    setStep(5)
+  const validate = async () => {
+    if (!client) return
+    setSaving(true)
+    const items = selectedCats.map((cat) => ({
+      tariffGroupId: cat.id,
+      quantity: quantities[cat.id],
+    }))
+    const res = await apiFetch('/tours', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        date: new Date().toISOString().split('T')[0],
+        clientId: client.id,
+        items,
+      }),
+    })
+    setSaving(false)
+    if (res.ok) {
+      setStep(5)
+    } else {
+      setError("Erreur lors de l'enregistrement")
+    }
   }
 
   return (
@@ -94,6 +118,7 @@ export default function TourneeWizard({ mode }: { mode: Mode }) {
       {step === 1 && (
         <>
           <h1 className="mb-6 text-3xl font-bold">Choisissez un client</h1>
+          {error && <p className="mb-4 text-red-600">{error}</p>}
           {clients.map((c) => (
             <button
               key={c.id}
@@ -191,11 +216,13 @@ export default function TourneeWizard({ mode }: { mode: Mode }) {
             </button>
             <button
               onClick={validate}
-              className="rounded bg-green-600 px-4 py-2 text-white"
+              disabled={saving}
+              className="rounded bg-green-600 px-4 py-2 text-white disabled:opacity-50"
             >
-              Valider
+              {saving ? 'Enregistrement...' : 'Valider'}
             </button>
           </div>
+          {error && <p className="mt-2 text-red-600">{error}</p>}
         </>
       )}
 

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -37,13 +37,6 @@ export async function apiFetch(path: string, init: RequestInit = {}) {
   const base = typeof window === 'undefined' ? API_BASE_INTERNAL : API_BASE_EXTERNAL
   const response = await fetch(`${base}${path}`, { ...init, headers })
 
-  if (response.status === 401) {
-    if (typeof window !== 'undefined') {
-      window.location.href = '/api/auth/login'
-    } else {
-      throw new Error('Unauthorized')
-    }
-  }
-
+  // Do not force navigation on 401; let callers handle unauthorized cases.
   return response
 }


### PR DESCRIPTION
## Summary
- avoid page reload loops by returning 401 responses from apiFetch instead of redirecting
- surface unauthorized errors in the tour wizard and add loading states to driver pages

## Testing
- `pytest`
- `cd frontend && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c818abea1c832c950cce9552772308