### PR TITLE
fix: avoid auth loss on client list

### DIFF
--- a/frontend/app/declarer/page.tsx
+++ b/frontend/app/declarer/page.tsx
@@ -29,7 +29,7 @@ export default function DeclarerPage() {
   useEffect(() => {
     if (!isDriver) return
     const fetchClients = async () => {
-      const res = await apiFetch('/clients')
+      const res = await apiFetch('/clients/')
       if (res.ok) {
         const data = await res.json()
         setClients(data)
@@ -43,7 +43,7 @@ export default function DeclarerPage() {
     if (!qtyStr) return
     const quantity = Number(qtyStr)
     if (isNaN(quantity)) return
-    const res = await apiFetch('/tours', {
+    const res = await apiFetch('/tours/', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/frontend/components/ClientManager.tsx
+++ b/frontend/components/ClientManager.tsx
@@ -30,7 +30,7 @@ export default function ClientManager() {
 
   useEffect(() => {
     const load = async () => {
-      const res = await apiFetch('/clients')
+      const res = await apiFetch('/clients/')
       if (res.ok) {
         const data = await res.json()
         const mapped: Client[] = data.map((c: any) => ({
@@ -65,7 +65,7 @@ export default function ClientManager() {
         prev.map((c) => (c.id === editingClient.id ? { ...c, name } : c)),
       )
     } else {
-      const res = await apiFetch('/clients', {
+      const res = await apiFetch('/clients/', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name }),

--- a/frontend/components/TourneeWizard.tsx
+++ b/frontend/components/TourneeWizard.tsx
@@ -29,7 +29,7 @@ export default function TourneeWizard({ mode }: { mode: Mode }) {
 
   useEffect(() => {
     const fetchClients = async () => {
-      const res = await apiFetch('/clients')
+      const res = await apiFetch('/clients/')
       if (res.ok) {
         const data = await res.json()
         setClients(data)
@@ -96,7 +96,7 @@ export default function TourneeWizard({ mode }: { mode: Mode }) {
       tariffGroupId: cat.id,
       quantity: quantities[cat.id],
     }))
-    const res = await apiFetch('/tours', {
+    const res = await apiFetch('/tours/', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({


### PR DESCRIPTION
## Summary
- ensure frontend calls clients API with trailing slash so auth headers survive redirects
- use trailing slash for tour creation endpoints

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c8314296d4832caecdd2b03e86d6a5