### PR TITLE
Allow localhost ports in CORS defaults

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -2,6 +2,14 @@ from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings
 
 
+DEFAULT_LOCALHOST_ORIGINS = (
+    "http://localhost:3000",
+    "http://127.0.0.1:3000",
+    "http://localhost:8000",
+    "http://127.0.0.1:8000",
+)
+
+
 class Settings(BaseSettings):
     database_url: str = "postgresql+psycopg://delivops:changeme@db:5432/delivops"
     auth0_domain: str = "dev-or3c4n80x1rba26g.eu.auth0.com"
@@ -12,7 +20,7 @@ class Settings(BaseSettings):
     dev_fake_auth: bool = False
     loki_url: str | None = None
     cors_allow_origins: list[str] = Field(
-        default_factory=lambda: ["http://localhost:3000", "http://127.0.0.1:3000"]
+        default_factory=lambda: list(DEFAULT_LOCALHOST_ORIGINS)
     )
     cors_allow_origin_regex: str | None = r"https?://(localhost|127\.0\.0\.1)(:\d+)?$"
 

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -21,3 +21,20 @@ def test_cors_allows_loopback_origins():
         response.headers.get("access-control-allow-origin")
         == "http://127.0.0.1:5173"
     )
+
+
+def test_cors_allows_localhost_3000():
+    response = client.options(
+        "/clients/",
+        headers={
+            "origin": "http://localhost:3000",
+            "access-control-request-method": "GET",
+            "access-control-request-headers": "x-tenant-id",
+        },
+    )
+
+    assert response.status_code == 200
+    assert (
+        response.headers.get("access-control-allow-origin")
+        == "http://localhost:3000"
+    )


### PR DESCRIPTION
## Summary
- extend the default CORS allow list to cover both localhost:3000 and localhost:8000 for local development
- add a regression test confirming that requests from localhost:3000 receive the appropriate CORS headers

## Testing
- pytest tests/test_cors.py

------
https://chatgpt.com/codex/tasks/task_e_68c98800b6dc832ca8d57e0670a5e5a8