### PR TITLE
Handle string CORS origin environment values

### DIFF
--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -21,3 +21,20 @@ def test_cors_allows_loopback_origins():
         response.headers.get("access-control-allow-origin")
         == "http://127.0.0.1:5173"
     )
+
+
+def test_cors_allows_localhost_3000():
+    response = client.options(
+        "/clients/",
+        headers={
+            "origin": "http://localhost:3000",
+            "access-control-request-method": "GET",
+            "access-control-request-headers": "x-tenant-id",
+        },
+    )
+
+    assert response.status_code == 200
+    assert (
+        response.headers.get("access-control-allow-origin")
+        == "http://localhost:3000"
+    )

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -1,0 +1,27 @@
+import importlib
+
+import pytest
+
+from app.core import config as config_module
+from app.core.config import Settings
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("http://localhost:3000,http://localhost:8000", ["http://localhost:3000", "http://localhost:8000"]),
+        ("http://localhost:3000 http://localhost:8000", ["http://localhost:3000", "http://localhost:8000"]),
+        ("[\"http://localhost:3000\", \"http://localhost:8000\"]", ["http://localhost:3000", "http://localhost:8000"]),
+    ],
+)
+
+def test_settings_parses_cors_allow_origins(monkeypatch, value, expected):
+    monkeypatch.setenv("CORS_ALLOW_ORIGINS", value)
+    settings = Settings()
+    assert settings.cors_allow_origins == expected
+
+
+def test_reload_settings_uses_default_when_env_not_set(monkeypatch):
+    monkeypatch.delenv("CORS_ALLOW_ORIGINS", raising=False)
+    importlib.reload(config_module)
+    assert "http://localhost:3000" in config_module.settings.cors_allow_origins


### PR DESCRIPTION
## Summary
- normalize CORS origin configuration so string environment values split on commas or whitespace and always yield a list
- add regression coverage to ensure Settings accepts various env formats and keeps default localhost origins when unset

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c98800b6dc832ca8d57e0670a5e5a8