### PR TITLE
Soft delete clients and categories

### DIFF
--- a/backend/app/api/clients.py
+++ b/backend/app/api/clients.py
@@ -155,7 +155,18 @@ def delete_client(
     )
     if not client:
         raise HTTPException(status_code=404, detail="Client not found")
-    db.delete(client)
+    groups = (
+        db.query(TariffGroup)
+        .filter(
+            TariffGroup.tenant_id == tenant_id_int,
+            TariffGroup.client_id == client.id,
+            TariffGroup.is_active.is_(True),
+        )
+        .all()
+    )
+    for group in groups:
+        group.is_active = False
+    client.is_active = False
     db.commit()
     return None
 
@@ -255,6 +266,6 @@ def delete_category(
     )
     if not group:
         raise HTTPException(status_code=404, detail="Category not found")
-    db.delete(group)
+    group.is_active = False
     db.commit()
     return None


### PR DESCRIPTION
## Summary
- mark deleted clients as inactive and deactivate their tariff groups instead of removing records
- update the category deletion endpoint to perform a soft delete for tariff groups
- add a regression test ensuring DELETE /clients/{id} returns 204 and deactivates both client and category

## Testing
- pytest tests/test_clients.py

------
https://chatgpt.com/codex/tasks/task_e_68cbc0476358832ca570e56d82abc345