### PR TITLE
Fix Alembic env import path for migrations

### DIFF
--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -1,7 +1,14 @@
 from logging.config import fileConfig
+import sys
+from pathlib import Path
+
 from sqlalchemy import engine_from_config
 from sqlalchemy import pool
 from alembic import context
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+if str(BASE_DIR) not in sys.path:
+    sys.path.insert(0, str(BASE_DIR))
 
 from app.core.config import settings
 from app.models import base  # import Base and models


### PR DESCRIPTION
## Summary
- ensure Alembic env config appends the backend source directory to `sys.path` so the `app` package is importable when Alembic runs inside Docker

## Testing
- make migrate *(fails: docker: not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc15e7f9b4832c8ce9e1c2abbece6e