### PR TITLE
Handle Next proxy fallback when Docker host is unavailable

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -11,10 +11,71 @@ function normalizeProxyTarget(input) {
   return trimmed.replace(/\/+$/, '')
 }
 
+const dns = require('dns').promises
+
 const proxyTarget =
   normalizeProxyTarget(process.env.API_PROXY_TARGET) ??
   normalizeProxyTarget(process.env.API_BASE_INTERNAL) ??
   normalizeProxyTarget('http://localhost:8000')
+
+function resolveFallbackTarget(target) {
+  if (!target) {
+    return undefined
+  }
+
+  try {
+    const parsed = new URL(target)
+    if (parsed.hostname !== 'api') {
+      return undefined
+    }
+
+    const rawFallbackHost = process.env.API_PROXY_FALLBACK_HOST
+    const normalizedFallbackHost = rawFallbackHost?.trim()
+    const fallbackHost = normalizedFallbackHost && normalizedFallbackHost.length > 0 ? normalizedFallbackHost : 'localhost'
+    const portSegment = parsed.port ? `:${parsed.port}` : ''
+
+    return normalizeProxyTarget(`${parsed.protocol}//${fallbackHost}${portSegment}`)
+  } catch (error) {
+    console.warn('Unable to compute fallback proxy target for %s: %s', target, error)
+    return undefined
+  }
+}
+
+async function determineProxyTarget(target) {
+  if (!target) {
+    return undefined
+  }
+
+  let parsed
+  try {
+    parsed = new URL(target)
+  } catch (error) {
+    console.warn('Invalid proxy target URL %s: %s', target, error)
+    return target
+  }
+
+  if (parsed.hostname !== 'api') {
+    return target
+  }
+
+  const fallbackTarget = resolveFallbackTarget(target)
+  if (!fallbackTarget) {
+    return target
+  }
+
+  try {
+    await dns.lookup(parsed.hostname)
+    return target
+  } catch (error) {
+    console.warn(
+      'Proxy target host %s is not resolvable; falling back to %s. Original error: %s',
+      parsed.hostname,
+      fallbackTarget,
+      error,
+    )
+    return fallbackTarget
+  }
+}
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -23,10 +84,15 @@ const nextConfig = {
       return []
     }
 
+    const resolvedTarget = await determineProxyTarget(proxyTarget)
+    if (!resolvedTarget) {
+      return []
+    }
+
     return [
       {
         source: '/api/proxy/:path*',
-        destination: `${proxyTarget}/:path*`,
+        destination: `${resolvedTarget}/:path*`,
       },
     ]
   },


### PR DESCRIPTION
## Summary
- detect when the configured API proxy target uses the Docker "api" hostname
- fall back to a localhost-based target when the hostname cannot be resolved, while allowing an override

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd9fdf899c832cb0758e1226c6da1c