### PR TITLE
Adjust Next.js proxy target handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ NEXT_PUBLIC_DEV_SUB=demo-user
 - `NEXT_PUBLIC_API_BASE` pointe vers le proxy Next.js (`/api/proxy`) qui relaie les appels navigateur vers FastAPI.
 - `NEXT_PUBLIC_DEV_ROLE` et `NEXT_PUBLIC_DEV_SUB` pilotent les entêtes injectés par le front lorsque `DEV_FAKE_AUTH=1`.
 - `API_BASE_INTERNAL` est utilisé par le rendu côté serveur de Next.js. En environnement Docker, remplacez-le par `http://api:8000` (valeur déjà fournie dans `.env.local`).
-- Vous pouvez rediriger la cible du proxy via `API_PROXY_TARGET`; sinon, `API_BASE_INTERNAL` est utilisée par défaut.
+- `API_PROXY_TARGET` permet de surcharger la destination du proxy Next.js. Par défaut, les requêtes `/api/proxy` sont redirigées vers `http://localhost:8000`. Dans l'environnement Docker Compose, cette variable est définie à `http://api:8000` pour viser le conteneur FastAPI ; ajustez-la si votre API est exposée sur un autre hôte.
 
 Le fichier `.env.local` est automatiquement pris en compte par `docker-compose`.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       - ./frontend/.env.local
     environment:
       - PORT=3000
+      - API_PROXY_TARGET=http://api:8000
     ports:
       - "3000:3000"
     depends_on:

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -7,3 +7,5 @@ NEXT_PUBLIC_API_BASE=http://localhost:8000
 NEXT_PUBLIC_AUTH0_AUDIENCE=https://delivops-codex.api/
 NEXT_PUBLIC_DEV_ROLE=ADMIN
 NEXT_PUBLIC_DEV_SUB=demo-user
+# Décommentez pour surcharger la cible du proxy Next.js si l'API tourne sur un autre hôte
+# API_PROXY_TARGET=http://api:8000

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -11,71 +11,11 @@ function normalizeProxyTarget(input) {
   return trimmed.replace(/\/+$/, '')
 }
 
-const dns = require('dns').promises
+const DEFAULT_PROXY_TARGET = 'http://localhost:8000'
 
 const proxyTarget =
   normalizeProxyTarget(process.env.API_PROXY_TARGET) ??
-  normalizeProxyTarget(process.env.API_BASE_INTERNAL) ??
-  normalizeProxyTarget('http://localhost:8000')
-
-function resolveFallbackTarget(target) {
-  if (!target) {
-    return undefined
-  }
-
-  try {
-    const parsed = new URL(target)
-    if (parsed.hostname !== 'api') {
-      return undefined
-    }
-
-    const rawFallbackHost = process.env.API_PROXY_FALLBACK_HOST
-    const normalizedFallbackHost = rawFallbackHost?.trim()
-    const fallbackHost = normalizedFallbackHost && normalizedFallbackHost.length > 0 ? normalizedFallbackHost : 'localhost'
-    const portSegment = parsed.port ? `:${parsed.port}` : ''
-
-    return normalizeProxyTarget(`${parsed.protocol}//${fallbackHost}${portSegment}`)
-  } catch (error) {
-    console.warn('Unable to compute fallback proxy target for %s: %s', target, error)
-    return undefined
-  }
-}
-
-async function determineProxyTarget(target) {
-  if (!target) {
-    return undefined
-  }
-
-  let parsed
-  try {
-    parsed = new URL(target)
-  } catch (error) {
-    console.warn('Invalid proxy target URL %s: %s', target, error)
-    return target
-  }
-
-  if (parsed.hostname !== 'api') {
-    return target
-  }
-
-  const fallbackTarget = resolveFallbackTarget(target)
-  if (!fallbackTarget) {
-    return target
-  }
-
-  try {
-    await dns.lookup(parsed.hostname)
-    return target
-  } catch (error) {
-    console.warn(
-      'Proxy target host %s is not resolvable; falling back to %s. Original error: %s',
-      parsed.hostname,
-      fallbackTarget,
-      error,
-    )
-    return fallbackTarget
-  }
-}
+  DEFAULT_PROXY_TARGET
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -84,15 +24,10 @@ const nextConfig = {
       return []
     }
 
-    const resolvedTarget = await determineProxyTarget(proxyTarget)
-    if (!resolvedTarget) {
-      return []
-    }
-
     return [
       {
         source: '/api/proxy/:path*',
-        destination: `${resolvedTarget}/:path*`,
+        destination: `${proxyTarget}/:path*`,
       },
     ]
   },


### PR DESCRIPTION
## Summary
- simplify the Next.js proxy configuration to default to http://localhost:8000 when API_PROXY_TARGET is not provided
- configure the docker-compose web service with API_PROXY_TARGET so the proxy continues to target the API container internally
- document how to override API_PROXY_TARGET and update the sample frontend environment file accordingly

## Testing
- npm run lint --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68cda9664c68832c964ea0a13c6c04b8