### PR TITLE
Allow clients endpoints without trailing slash

### DIFF
--- a/backend/app/api/clients.py
+++ b/backend/app/api/clients.py
@@ -30,6 +30,7 @@ def slugify(text: str) -> str:
     return re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
 
 
+@router.get("", response_model=List[ClientWithCategories], include_in_schema=False)
 @router.get("/", response_model=List[ClientWithCategories])
 def list_clients(
     db: Session = Depends(get_db),  # noqa: B008
@@ -89,6 +90,7 @@ def list_clients(
     return result
 
 
+@router.post("", response_model=ClientWithCategories, status_code=201, include_in_schema=False)
 @router.post("/", response_model=ClientWithCategories, status_code=201)
 def create_client(
     payload: ClientCreate,


### PR DESCRIPTION
## Summary
- allow the clients router to serve GET/POST on `/clients` without redirecting to the trailing slash variant

## Testing
- ⚠️ `make test` *(fails: docker: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68cdace2b03c832cad3204f79cdb95db