### PR TITLE
Handle POST root paths for creation endpoints

### DIFF
--- a/backend/app/api/saisies.py
+++ b/backend/app/api/saisies.py
@@ -10,6 +10,7 @@ from app.schemas.saisie import SaisieCreate, SaisieUpdate, SaisieRead
 router = APIRouter(prefix="/saisies", tags=["saisies"])
 
 
+@router.post("", response_model=SaisieRead, status_code=201, include_in_schema=False)
 @router.post("/", response_model=SaisieRead, status_code=201)
 def create_saisie(
     saisie_in: SaisieCreate,

--- a/backend/app/api/tarifs.py
+++ b/backend/app/api/tarifs.py
@@ -19,6 +19,7 @@ def _get_client_for_tenant(db: Session, client_id: int, tenant_id: int) -> Clien
     return client
 
 
+@router.post("", response_model=TarifRead, status_code=201, include_in_schema=False)
 @router.post("/", response_model=TarifRead, status_code=201)
 def create_tarif(
     tarif_in: TarifCreate,

--- a/backend/app/api/tours.py
+++ b/backend/app/api/tours.py
@@ -32,6 +32,7 @@ def _get_driver_from_user(db: Session, tenant_id: int, user_sub: str) -> Chauffe
     return chauffeur
 
 
+@router.post("", response_model=TourRead, status_code=201, include_in_schema=False)
 @router.post("/", response_model=TourRead, status_code=201)
 def create_tour(
     tour_in: TourCreate,


### PR DESCRIPTION
## Summary
- add explicit POST route aliases without trailing slashes for tours, tarifs, and saisies

## Testing
- make test *(fails: docker executable is not available in the environment)*
- curl -i http://localhost:3000/api/proxy/tours *(fails: connection refused because the proxy service is not running in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d158de96dc832c9d644930f4d7447e