### PR TITLE
Clarify pgAdmin password configuration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Les services sont ensuite accessibles :
 
 - API : http://localhost:8000
 - Frontend : http://localhost:3000
+- pgAdmin : http://localhost:5050
 
 ## Rôles et permissions
 
@@ -90,6 +91,31 @@ Une stack Grafana/Loki accompagne le projet pour le suivi des `AuditLog` :
 
 - Grafana : http://localhost:3001
 - Dashboard "Chauffeurs par utilisateur" pré-provisionné.
+
+## Administration de la base de données
+
+pgAdmin est intégré à l'environnement Docker Compose pour administrer la base PostgreSQL.
+
+- URL : http://localhost:5050
+- Identifiant : `admin@delivops.local`
+- Mot de passe : `changeme` (ou la valeur fournie via `PGADMIN_DEFAULT_PASSWORD`)
+
+Pour définir un mot de passe différent :
+
+- exportez la variable dans votre shell **dans le même terminal que celui où vous lancerez** `make dev` :
+
+  ```bash
+  export PGADMIN_DEFAULT_PASSWORD='motdepasse-sécurisé'
+  make dev
+  ```
+
+- ou créez un fichier `.env` à la racine du dépôt (lu automatiquement par Docker Compose) contenant :
+
+  ```
+  PGADMIN_DEFAULT_PASSWORD=motdepasse-sécurisé
+  ```
+
+Dans les deux cas, relancez ensuite `make dev` pour (re)créer le conteneur pgAdmin avec ce mot de passe.
 
 ## Gestion des données
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,5 +57,17 @@ services:
       - ./observability/grafana/provisioning:/etc/grafana/provisioning
     depends_on:
       - loki
+  pgadmin:
+    image: dpage/pgadmin4:8.7
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@delivops.local
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-changeme}
+    ports:
+      - "5050:80"
+    volumes:
+      - pgadmin_data:/var/lib/pgadmin
+    depends_on:
+      - db
 volumes:
   db_data:
+  pgadmin_data:


### PR DESCRIPTION
## Summary
- add a pgAdmin container to the docker-compose stack with persistent storage
- document default credentials and clarify how to override the pgAdmin password via `PGADMIN_DEFAULT_PASSWORD`

## Testing
- docker compose config *(fails: docker command not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3a152e458832c86b02d6c4efde209