### PR TITLE
Handle tours without declarations in admin report

### DIFF
--- a/backend/app/schemas/tour.py
+++ b/backend/app/schemas/tour.py
@@ -68,7 +68,7 @@ class TourRead(BaseModel):
 
 class DeclarationReportLine(BaseModel):
     tour_id: int = Field(alias="tourId")
-    tour_item_id: int = Field(alias="tourItemId")
+    tour_item_id: int | None = Field(alias="tourItemId")
     date: date
     driver_name: str = Field(alias="driverName")
     client_name: str = Field(alias="clientName")
@@ -78,6 +78,7 @@ class DeclarationReportLine(BaseModel):
     difference_quantity: int = Field(alias="differenceQuantity")
     estimated_amount_eur: Decimal = Field(alias="estimatedAmountEur")
     unit_price_ex_vat: Decimal = Field(alias="unitPriceExVat")
+    status: Literal["IN_PROGRESS", "COMPLETED"]
 
     model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 


### PR DESCRIPTION
## Summary
- return all in-progress tours from the declaration report even when they do not yet have tour items, filling placeholder quantities
- allow the declaration schema and admin page to handle rows that have no tour item id and disable edit/delete on those entries
- extend the backend test suite to cover tours without items and keep UI keys stable for placeholder rows

## Testing
- pytest backend/tests/test_tours_declaration.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d2c4360dc0832cb8552b3adab884c2