### PR TITLE
Include inactive clients in reports filters

### DIFF
--- a/backend/app/schemas/client.py
+++ b/backend/app/schemas/client.py
@@ -1,6 +1,6 @@
+from decimal import Decimal
 from typing import List
 
-from decimal import Decimal
 from pydantic import BaseModel, Field, ConfigDict
 
 
@@ -31,7 +31,10 @@ class CategoryUpdate(BaseModel):
 class ClientWithCategories(BaseModel):
     id: int
     name: str
+    is_active: bool = Field(alias="isActive")
     categories: List[CategoryRead]
+
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
 
 class ClientCreate(BaseModel):

--- a/frontend/components/ClientManager.tsx
+++ b/frontend/components/ClientManager.tsx
@@ -57,6 +57,7 @@ const mapCategoryFromApi = (
 const mapClientFromApi = (client: ClientApiPayload): Client => ({
   id: client.id,
   name: client.name,
+  isActive: client.isActive ?? true,
   categories: client.categories.map((cat, idx) =>
     mapCategoryFromApi(cat, COLORS[idx % COLORS.length]),
   ),

--- a/frontend/components/types.ts
+++ b/frontend/components/types.ts
@@ -8,6 +8,7 @@ export type TariffCategory = {
 export type Client = {
   id: number
   name: string
+  isActive: boolean
   categories: TariffCategory[]
 }
 
@@ -20,5 +21,6 @@ export type ClientCategoryApiPayload = {
 export type ClientApiPayload = {
   id: number
   name: string
+  isActive?: boolean
   categories: ClientCategoryApiPayload[]
 }


### PR DESCRIPTION
## Summary
- allow the clients API to optionally include inactive clients and expose their active flag in responses
- extend the client schema and test suite to cover the new include_inactive query parameter
- update the synthèse interface to fetch inactive clients, surface their status in filters, and keep creation from using them

## Testing
- pytest tests/test_clients.py
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3ca71bb80832ca6cdf1b88a2d0fb0