### PR TITLE
Default driver synthesis period filter to current month

### DIFF
--- a/frontend/app/chauffeurs/synthese/page.tsx
+++ b/frontend/app/chauffeurs/synthese/page.tsx
@@ -60,6 +60,23 @@ interface FiltersState {
   tariffGroupName: string
 }
 
+const getCurrentMonthString = () => {
+  const now = new Date()
+  const month = String(now.getMonth() + 1).padStart(2, '0')
+  return `${now.getFullYear()}-${month}`
+}
+
+const createDefaultFiltersState = (): FiltersState => ({
+  dateMode: 'month',
+  day: '',
+  month: getCurrentMonthString(),
+  dateFrom: '',
+  dateTo: '',
+  driverId: '',
+  clientId: '',
+  tariffGroupName: '',
+})
+
 export default function SyntheseChauffeursPage() {
   const { user } = useUser()
   const roles = normalizeRoles(
@@ -69,16 +86,9 @@ export default function SyntheseChauffeursPage() {
   const [rows, setRows] = useState<DeclarationRow[]>([])
   const [drivers, setDrivers] = useState<DriverOption[]>([])
   const [clients, setClients] = useState<ClientOption[]>([])
-  const [filters, setFilters] = useState<FiltersState>({
-    dateMode: 'day',
-    day: '',
-    month: '',
-    dateFrom: '',
-    dateTo: '',
-    driverId: '',
-    clientId: '',
-    tariffGroupName: '',
-  })
+  const [filters, setFilters] = useState<FiltersState>(() =>
+    createDefaultFiltersState(),
+  )
   const [error, setError] = useState('')
   const [editingId, setEditingId] = useState<number | null>(null)
   const [formValues, setFormValues] = useState({
@@ -184,7 +194,7 @@ export default function SyntheseChauffeursPage() {
           ...prev,
           dateMode: value as FiltersState['dateMode'],
           day: '',
-          month: '',
+          month: value === 'month' ? getCurrentMonthString() : '',
           dateFrom: '',
           dateTo: '',
         }
@@ -210,16 +220,7 @@ export default function SyntheseChauffeursPage() {
   }
 
   const resetFilters = () => {
-    setFilters({
-      dateMode: 'day',
-      day: '',
-      month: '',
-      dateFrom: '',
-      dateTo: '',
-      driverId: '',
-      clientId: '',
-      tariffGroupName: '',
-    })
+    setFilters(createDefaultFiltersState())
   }
 
   const driverFilterOptions = useMemo(


### PR DESCRIPTION
## Summary
- default the driver synthesis period filter to month mode with the current month selected
- ensure resetting filters restores the month-based defaults

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3cf7be2e8832c89b0657d32161778