### PR TITLE
Add tariff margin support and driver margin reporting

### DIFF
--- a/backend/app/models/tariff.py
+++ b/backend/app/models/tariff.py
@@ -14,6 +14,7 @@ class Tariff(Base):
         Integer, ForeignKey("tariffgroup.id"), nullable=False, index=True
     )
     price_ex_vat = Column(Numeric(10, 2), default=Decimal("0"))
+    margin_ex_vat = Column(Numeric(10, 2), default=Decimal("0"))
     vat_rate = Column(Numeric(5, 2), default=Decimal("0"))
     effective_from = Column(Date, nullable=False)
     effective_to = Column(Date, nullable=True)

--- a/backend/app/models/tour_item.py
+++ b/backend/app/models/tour_item.py
@@ -18,6 +18,8 @@ class TourItem(Base):
     delivery_quantity = Column(Integer, nullable=False, default=0)
     unit_price_ex_vat_snapshot = Column(Numeric(10, 2), default=Decimal("0"))
     amount_ex_vat_snapshot = Column(Numeric(10, 2), default=Decimal("0"))
+    unit_margin_ex_vat_snapshot = Column(Numeric(10, 2), default=Decimal("0"))
+    margin_ex_vat_snapshot = Column(Numeric(10, 2), default=Decimal("0"))
 
     tour = relationship("Tour", back_populates="items")
     tariff_group = relationship("TariffGroup")

--- a/backend/app/schemas/client.py
+++ b/backend/app/schemas/client.py
@@ -10,6 +10,7 @@ class CategoryRead(BaseModel):
     unit_price_ex_vat: Decimal | None = Field(
         default=None, alias="unitPriceExVat"
     )
+    margin_ex_vat: Decimal | None = Field(default=None, alias="marginExVat")
 
     model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
@@ -19,6 +20,7 @@ class CategoryCreate(BaseModel):
     unit_price_ex_vat: Decimal | None = Field(
         default=None, alias="unitPriceExVat"
     )
+    margin_ex_vat: Decimal | None = Field(default=None, alias="marginExVat")
 
 
 class CategoryUpdate(BaseModel):
@@ -26,6 +28,7 @@ class CategoryUpdate(BaseModel):
     unit_price_ex_vat: Decimal | None = Field(
         default=None, alias="unitPriceExVat"
     )
+    margin_ex_vat: Decimal | None = Field(default=None, alias="marginExVat")
 
 
 class ClientWithCategories(BaseModel):

--- a/backend/app/schemas/tour.py
+++ b/backend/app/schemas/tour.py
@@ -41,6 +41,8 @@ class TourItemRead(BaseModel):
     difference: int
     unit_price_ex_vat: Decimal = Field(alias="unitPriceExVat")
     amount_ex_vat: Decimal = Field(alias="amountExVat")
+    unit_margin_ex_vat: Decimal = Field(alias="unitMarginExVat")
+    margin_amount_ex_vat: Decimal = Field(alias="marginAmountEur")
 
     model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
@@ -50,6 +52,7 @@ class TourTotals(BaseModel):
     delivery_qty: int = Field(alias="deliveryQty")
     difference_qty: int = Field(alias="differenceQty")
     amount_ex_vat: Decimal = Field(alias="amountExVat")
+    margin_amount_ex_vat: Decimal = Field(alias="marginAmountEur")
 
     model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
@@ -78,6 +81,8 @@ class DeclarationReportLine(BaseModel):
     difference_quantity: int = Field(alias="differenceQuantity")
     estimated_amount_eur: Decimal = Field(alias="estimatedAmountEur")
     unit_price_ex_vat: Decimal = Field(alias="unitPriceExVat")
+    unit_margin_ex_vat: Decimal = Field(alias="unitMarginExVat")
+    margin_amount_eur: Decimal = Field(alias="marginAmountEur")
     status: Literal["IN_PROGRESS", "COMPLETED"]
 
     model_config = ConfigDict(from_attributes=True, populate_by_name=True)

--- a/backend/migrations/versions/0006_tariff_margin.py
+++ b/backend/migrations/versions/0006_tariff_margin.py
@@ -1,0 +1,56 @@
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0006_tariff_margin"
+down_revision = "0005_unify_tours"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "tariff",
+        sa.Column(
+            "margin_ex_vat",
+            sa.Numeric(10, 2),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+    op.add_column(
+        "touritem",
+        sa.Column(
+            "unit_margin_ex_vat_snapshot",
+            sa.Numeric(10, 2),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+    op.add_column(
+        "touritem",
+        sa.Column(
+            "margin_ex_vat_snapshot",
+            sa.Numeric(10, 2),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+
+    op.alter_column("tariff", "margin_ex_vat", server_default=None)
+    op.alter_column(
+        "touritem",
+        "unit_margin_ex_vat_snapshot",
+        server_default=None,
+    )
+    op.alter_column(
+        "touritem",
+        "margin_ex_vat_snapshot",
+        server_default=None,
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("touritem", "margin_ex_vat_snapshot")
+    op.drop_column("touritem", "unit_margin_ex_vat_snapshot")
+    op.drop_column("tariff", "margin_ex_vat")

--- a/frontend/components/CategoryForm.tsx
+++ b/frontend/components/CategoryForm.tsx
@@ -25,6 +25,7 @@ export default function CategoryForm({
 }: Props) {
   const [name, setName] = useState(initialCategory?.name ?? '')
   const [price, setPrice] = useState(initialCategory?.price ?? '')
+  const [margin, setMargin] = useState(initialCategory?.margin ?? '')
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault()
@@ -32,6 +33,7 @@ export default function CategoryForm({
       id: initialCategory?.id ?? 0,
       name,
       price: formatPrice(price),
+      margin: formatPrice(margin),
       color: initialCategory?.color ?? '',
     })
   }
@@ -64,6 +66,22 @@ export default function CategoryForm({
           onBlur={(e) => setPrice(formatPrice(e.target.value))}
           className="w-full rounded border p-2"
           placeholder="Tarif en €"
+          required
+        />
+      </div>
+      <div className="mb-4">
+        <label className="mb-1 block font-medium" htmlFor="margin">
+          Marge
+        </label>
+        <input
+          id="margin"
+          type="number"
+          step="0.01"
+          value={margin}
+          onChange={(e) => setMargin(e.target.value)}
+          onBlur={(e) => setMargin(formatPrice(e.target.value))}
+          className="w-full rounded border p-2"
+          placeholder="Marge en €"
           required
         />
       </div>

--- a/frontend/components/ClientCard.tsx
+++ b/frontend/components/ClientCard.tsx
@@ -19,6 +19,14 @@ export default function ClientCard({
   onEditCategory,
   onDeleteCategory,
 }: Props) {
+  const formatAmount = (value: string) => {
+    const parsed = Number.parseFloat(value)
+    if (Number.isNaN(parsed)) {
+      return '0.00'
+    }
+    return parsed.toFixed(2)
+  }
+
   return (
     <div className="mb-4 rounded border p-4">
       <div className="flex items-center justify-between">
@@ -55,7 +63,8 @@ export default function ClientCard({
               <div className="flex justify-between">
                 <div>
                   <p className="font-medium">{cat.name}</p>
-                  <p>{parseFloat(cat.price).toFixed(2)} €</p>
+                  <p>Tarif : {formatAmount(cat.price)} €</p>
+                  <p>Marge : {formatAmount(cat.margin)} €</p>
                 </div>
                 <div className="space-x-2 text-sm">
                   <button

--- a/frontend/components/ClientManager.tsx
+++ b/frontend/components/ClientManager.tsx
@@ -51,6 +51,7 @@ const mapCategoryFromApi = (
   id: category.id,
   name: category.name,
   price: formatUnitPrice(category.unitPriceExVat),
+  margin: formatUnitPrice(category.marginExVat),
   color,
 })
 
@@ -206,6 +207,7 @@ export default function ClientManager() {
           body: JSON.stringify({
             name: category.name,
             unitPriceExVat: toUnitPricePayload(category.price),
+            marginExVat: toUnitPricePayload(category.margin),
           }),
         },
       )
@@ -240,6 +242,7 @@ export default function ClientManager() {
         body: JSON.stringify({
           name: category.name,
           unitPriceExVat: toUnitPricePayload(category.price),
+          marginExVat: toUnitPricePayload(category.margin),
         }),
       })
       if (res.ok) {

--- a/frontend/components/TourneeWizard.tsx
+++ b/frontend/components/TourneeWizard.tsx
@@ -8,6 +8,7 @@ interface Category {
   id: number
   name: string
   unitPriceExVat?: string
+  marginExVat?: string
 }
 
 interface Client {

--- a/frontend/components/types.ts
+++ b/frontend/components/types.ts
@@ -2,6 +2,7 @@ export type TariffCategory = {
   id: number
   name: string
   price: string
+  margin: string
   color: string
 }
 
@@ -16,6 +17,7 @@ export type ClientCategoryApiPayload = {
   id: number
   name: string
   unitPriceExVat?: string | null
+  marginExVat?: string | null
 }
 
 export type ClientApiPayload = {


### PR DESCRIPTION
## Summary
- store per-tariff margins and snapshot them on tour items, updating client APIs and schemas
- expose and persist margin inputs in the admin UI and client management forms
- display French-formatted dates and a margin column with totals on the driver summary table

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3d39d3610832c8c6be27b7181c9bf