### PR TITLE
Accept tenant slug identifiers

### DIFF
--- a/backend/app/api/chauffeurs.py
+++ b/backend/app/api/chauffeurs.py
@@ -20,9 +20,9 @@ router = APIRouter(prefix="/chauffeurs", tags=["chauffeurs"])
 @router.get("/count")
 def count_chauffeurs(
     db: Session = Depends(get_db),  # noqa: B008
-    tenant_id: str = Depends(get_tenant_id),  # noqa: B008
+    tenant_id: int = Depends(get_tenant_id),  # noqa: B008
 ):
-    service = ChauffeurService(db, int(tenant_id))
+    service = ChauffeurService(db, tenant_id)
     count, subscribed = service.count_and_subscription()
     return {"count": count, "subscribed": subscribed}
 
@@ -31,10 +31,10 @@ def count_chauffeurs(
 @router.get("/", response_model=list[ChauffeurRead])
 def list_chauffeurs(
     db: Session = Depends(get_db),  # noqa: B008
-    tenant_id: str = Depends(get_tenant_id),  # noqa: B008
+    tenant_id: int = Depends(get_tenant_id),  # noqa: B008
     user: dict = Depends(require_roles("ADMIN")),  # noqa: B008
 ):
-    service = ChauffeurService(db, int(tenant_id))
+    service = ChauffeurService(db, tenant_id)
     return service.list()
 
 
@@ -43,10 +43,10 @@ def list_chauffeurs(
 def create_chauffeur(
     chauffeur_in: ChauffeurCreate,
     db: Session = Depends(get_db),  # noqa: B008
-    tenant_id: str = Depends(get_tenant_id),  # noqa: B008
+    tenant_id: int = Depends(get_tenant_id),  # noqa: B008
     user: dict = Depends(require_roles("ADMIN")),  # noqa: B008
 ):
-    service = ChauffeurService(db, int(tenant_id))
+    service = ChauffeurService(db, tenant_id)
     user_sub = user.get("sub") if isinstance(user, dict) else None
     try:
         chauffeur = service.create(chauffeur_in, user_sub)
@@ -72,10 +72,10 @@ def update_chauffeur(
     chauffeur_id: int,
     chauffeur_in: ChauffeurUpdate,
     db: Session = Depends(get_db),  # noqa: B008
-    tenant_id: str = Depends(get_tenant_id),  # noqa: B008
+    tenant_id: int = Depends(get_tenant_id),  # noqa: B008
     user: dict = Depends(require_roles("ADMIN")),  # noqa: B008
 ):
-    service = ChauffeurService(db, int(tenant_id))
+    service = ChauffeurService(db, tenant_id)
     user_sub = user.get("sub") if isinstance(user, dict) else None
     try:
         return service.update(chauffeur_id, chauffeur_in, user_sub)
@@ -90,10 +90,10 @@ def update_chauffeur(
 def delete_chauffeur(
     chauffeur_id: int,
     db: Session = Depends(get_db),  # noqa: B008
-    tenant_id: str = Depends(get_tenant_id),  # noqa: B008
+    tenant_id: int = Depends(get_tenant_id),  # noqa: B008
     user: dict = Depends(require_roles("ADMIN")),  # noqa: B008
 ):
-    service = ChauffeurService(db, int(tenant_id))
+    service = ChauffeurService(db, tenant_id)
     user_sub = user.get("sub") if isinstance(user, dict) else None
     try:
         service.delete(chauffeur_id, user_sub)

--- a/backend/app/api/saisies.py
+++ b/backend/app/api/saisies.py
@@ -15,15 +15,14 @@ router = APIRouter(prefix="/saisies", tags=["saisies"])
 def create_saisie(
     saisie_in: SaisieCreate,
     db: Session = Depends(get_db),  # noqa: B008
-    tenant_id: str = Depends(get_tenant_id),  # noqa: B008
+    tenant_id: int = Depends(get_tenant_id),  # noqa: B008
     user: dict = Depends(require_roles("ADMIN")),  # noqa: B008
 ):
-    tenant_id_int = int(tenant_id)
     tournee = db.get(Tournee, saisie_in.tournee_id)
-    if tournee is None or tournee.tenant_id != tenant_id_int:
+    if tournee is None or tournee.tenant_id != tenant_id:
         raise HTTPException(status_code=404, detail="Tournee not found")
     saisie = Saisie(
-        tenant_id=tenant_id_int,
+        tenant_id=tenant_id,
         tournee_id=saisie_in.tournee_id,
         type=saisie_in.type,
         groupe_colis=saisie_in.groupe_colis,
@@ -42,12 +41,11 @@ def update_saisie(
     saisie_id: int,
     saisie_in: SaisieUpdate,
     db: Session = Depends(get_db),  # noqa: B008
-    tenant_id: str = Depends(get_tenant_id),  # noqa: B008
+    tenant_id: int = Depends(get_tenant_id),  # noqa: B008
     user: dict = Depends(require_roles("ADMIN")),  # noqa: B008
 ):
-    tenant_id_int = int(tenant_id)
     saisie = db.get(Saisie, saisie_id)
-    if saisie is None or saisie.tenant_id != tenant_id_int:
+    if saisie is None or saisie.tenant_id != tenant_id:
         raise HTTPException(status_code=404, detail="Saisie not found")
     if saisie_in.type is not None:
         saisie.type = saisie_in.type

--- a/backend/app/api/tournees.py
+++ b/backend/app/api/tournees.py
@@ -12,13 +12,12 @@ router = APIRouter(prefix="/tournees", tags=["tournees"])
 @router.get("/synthese")
 def synthese_tournees(
     db: Session = Depends(get_db),  # noqa: B008
-    tenant_id: str = Depends(get_tenant_id),  # noqa: B008
+    tenant_id: int = Depends(get_tenant_id),  # noqa: B008
     user: dict = Depends(require_roles("ADMIN")),  # noqa: B008
 ):
-    tenant_id_int = int(tenant_id)
     tournees = (
         db.query(Tournee)
-        .filter(Tournee.tenant_id == tenant_id_int)
+        .filter(Tournee.tenant_id == tenant_id)
         .order_by(Tournee.date)
         .all()
     )

--- a/backend/tests/test_clients.py
+++ b/backend/tests/test_clients.py
@@ -98,6 +98,24 @@ def test_create_client_and_category_visible_to_driver(client):
     )
 
 
+def test_client_routes_accept_tenant_slug(client):
+    with TestingSessionLocal() as db:
+        tenant = Tenant(name="Slug Tenant", slug="slug-tenant")
+        db.add(tenant)
+        db.commit()
+        db.refresh(tenant)
+
+    slug_header = tenant.slug.upper()
+    headers_admin = {"X-Tenant-Id": slug_header, "X-Dev-Role": "ADMIN"}
+
+    resp = client.post("/clients/", json={"name": "Slug Client"}, headers=headers_admin)
+    assert resp.status_code == 201
+
+    resp = client.get("/clients/", headers=headers_admin)
+    assert resp.status_code == 200
+    assert any(entry["name"] == "Slug Client" for entry in resp.json())
+
+
 def test_update_category_updates_tariff_price(client):
     with TestingSessionLocal() as db:
         tenant = Tenant(name="Acme", slug="acme-update-cat")


### PR DESCRIPTION
## Summary
- resolve tenant headers by looking up slugs before falling back to numeric ids and return the resolved tenant id
- update all API endpoints to rely on the integer tenant id from the dependency instead of manually casting
- add a regression test that exercises the client API with an uppercase tenant slug header

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3da9e2394832caebd464eae6d12a6