### PR TITLE
Add production docker-compose override

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,23 @@ Les services sont ensuite accessibles :
 - Frontend : http://localhost:3000
 - pgAdmin : http://localhost:5050
 
+### Mode production permanent
+
+Pour exécuter l'API et le frontend avec les mêmes commandes qu'en production, utilisez le fichier d'override `docker-compose.prod.yml` :
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up --build
+```
+
+- le service `api` est démarré sans `--reload` ;
+- le service `web` réalise automatiquement `npm run build` puis `npm run start`, ce qui force `NODE_ENV=production` et active l'usage du vrai jeton Auth0 côté frontend.
+
+Stoppez ensuite l'environnement via :
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.prod.yml down
+```
+
 ## Rôles et permissions
 
 | Rôle        | Permissions principales                              |

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,13 @@
+version: '3.9'
+services:
+  api:
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000
+    environment:
+      - LOKI_URL=http://loki:3100/loki/api/v1/push
+      - UVICORN_RELOAD=false
+  web:
+    command: ["sh", "-c", "npm run build && npm run start"]
+    environment:
+      - PORT=3000
+      - API_PROXY_TARGET=http://api:8000
+      - NODE_ENV=production


### PR DESCRIPTION
## Summary
- add a docker-compose override to run the stack with production commands
- document how to launch and stop the permanent production mode setup

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d427065b14832cbbf0151509eb184b